### PR TITLE
land rapid7#12361 spell multiple correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in making Metasploit -- and therefore, the
 world -- a better place!  Before you get started, review our
-[Code of Conduct].  There are mutliple ways to help beyond just writing code:
+[Code of Conduct].  There are multiple ways to help beyond just writing code:
  - [Submit bugs and feature requests] with detailed information about your issue or idea.
  - [Help fellow users with open issues] or [help fellow committers test recent pull requests].
  - [Report a security vulnerability in Metasploit itself] to Rapid7.


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

