### PR TITLE
Land rapid7#13131, bump Vagrant devenv to Ubuntu 18.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure(2) do |config|
   config.ssh.forward_x11 = true
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
   config.vm.network :forwarded_port, guest: 4444, host: 4444
   config.vm.provider "vmware" do |v|
 	  v.memory = 2048

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -9,7 +9,7 @@
 # a bug in a command on a linux computer for priv esc.
 #
 ###
-class MetasploitModule < Msf::Exploit::Remote
+class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
   include Msf::Post::Linux::Priv
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    # Make sure we can write our exploit and payload to the remote system
+    # Make sure we can write our exploit and payload to the local system
     unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

